### PR TITLE
Add support for Komodo 7.0+ (now that it's on Gecko 7)

### DIFF
--- a/extension/chrome.manifest
+++ b/extension/chrome.manifest
@@ -35,3 +35,6 @@ contract    @mozilla.org/network/protocol/about;1?what=remotexul  {aa76f1c0-a902
 
 # SeaMonkey.
 overlay chrome://navigator/content/navigator.xul  chrome://remotexulmanager/content/rxmBrowserOverlay.xul   application={92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}
+
+# Komodo IDE / Edit
+overlay chrome://komodo/content/komodo.xul chrome://remotexulmanager/content/rxmBrowserOverlay.xul

--- a/extension/content/rxmBrowserOverlay.xul
+++ b/extension/content/rxmBrowserOverlay.xul
@@ -47,4 +47,11 @@
       oncommand="RXULMChrome.BrowserOverlay.launchManager(event);" />
   </menupopup>
 
+  <!-- Tools popup (Komodo). -->
+  <menupopup id="popup_tools">
+    <menuitem id="rxm-main-menu-ko" label="&rxm.menu.label;"
+      accesskey="&rxm.menu.accesskey;"
+      oncommand="RXULMChrome.BrowserOverlay.launchManager(event);" />
+  </menupopup>
+
 </overlay>

--- a/extension/install.rdf
+++ b/extension/install.rdf
@@ -55,6 +55,23 @@
       </Description>
     </em:targetApplication>
 
+    <em:targetApplication>
+      <Description>
+        <!-- Komodo IDE -->
+        <em:id>{36E66FA0-F259-11D9-850E-000D935D3368}</em:id>
+        <em:minVersion>7.0</em:minVersion>
+        <em:maxVersion>7.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+    <em:targetApplication>
+      <Description>
+        <!-- Komodo Edit -->
+        <em:id>{b1042fb5-9e9c-11db-b107-000d935d3368}</em:id>
+        <em:minVersion>7.0</em:minVersion>
+        <em:maxVersion>7.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
     <!-- Localized versions of the description-->
     <em:localized>
       <Description>


### PR DESCRIPTION
We lost support for remote previewing of XUL files in Komodo 7.  This patch will add a menu item ("Remote XUL Manager" or something, I forget the label) to our tools menu otherwise we get no UI.  It also updates install.rdf to be K7 compatible.

Thanks,
- Carey
